### PR TITLE
Admin flow added

### DIFF
--- a/lib/cores/components/article_preview_home.dart
+++ b/lib/cores/components/article_preview_home.dart
@@ -35,23 +35,20 @@ class _ArticlePreviewHomeState extends State<ArticlePreviewHome> {
                 itemCount: viewModel.imageUrls.length,
                 itemBuilder: (context, index) {
                   final carousel = viewModel.carousel[index];
-                  return Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 8.w),
-                    child: ArticleCard(
-                      title: carousel.carouselName,
-                      articleId: carousel.articleId,
-                      imageUrl: carousel.carouselPhoto,
-                      onTap: () {
-                        print('Tapped article ID: ${carousel.articleId}');
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) =>
-                                ArticleView(articleId: carousel.articleId),
-                          ),
-                        );
-                      },
-                    ),
+                  return ArticleCard(
+                    title: carousel.carouselName,
+                    articleId: carousel.articleId,
+                    imageUrl: carousel.carouselPhoto,
+                    onTap: () {
+                      print('Tapped article ID: ${carousel.articleId}');
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) =>
+                              ArticleView(articleId: carousel.articleId),
+                        ),
+                      );
+                    },
                   );
                 }),
           );

--- a/lib/cores/components/splash_screen.dart
+++ b/lib/cores/components/splash_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -20,15 +21,20 @@ class SplashScreenState extends State<SplashScreen> {
 
   Future<void> checkLoginStatus() async {
     SharedPreferences pref = await SharedPreferences.getInstance();
-    bool isLoggedIn = pref.getBool('isLoggedIn') ?? false;
+    bool isUserLoggedIn = pref.getBool('isUserLoggedIn') ?? false;
+    bool isAdminLoggedIn = pref.getBool('isAdminLoggedIn') ?? false;
 
     // Splash screen loading time
     await Future.delayed(Duration(seconds: 2));
 
-    if (isLoggedIn) {
-      context.go('/home');
-    } else {
-      context.go('/login');
+    if (isUserLoggedIn) {
+      if (ctx.mounted) ctx.goNamed(paths.home);
+    }
+    else if (isAdminLoggedIn){
+      if (ctx.mounted) ctx.goNamed(paths.adminView);
+    }
+    else {
+      if (ctx.mounted) ctx.goNamed(paths.login);
     }
   }
 

--- a/lib/cores/components/success_page.dart
+++ b/lib/cores/components/success_page.dart
@@ -29,7 +29,7 @@ class SuccessPageState extends State<SuccessPage> {
   void initState() {
     super.initState();
     Future.delayed(const Duration(seconds: 5), () {
-      ctx.goNamed(paths.home);
+      !widget.isAdmin ? ctx.goNamed(paths.home) : ctx.goNamed(paths.adminView);
     });
   }
 
@@ -55,10 +55,10 @@ class SuccessPageState extends State<SuccessPage> {
               ),
               Gap(50.h),
               Text(
-                widget.isSend
-                    ? 'Payment Successful !'
-                    : widget.isAdmin
-                        ? 'Order has been verified'
+                widget.isAdmin
+                    ? 'Order has been verified'
+                    : widget.isSend
+                        ? 'Payment Successful !'
                         : 'Drop Off Successful !',
                 style: textTheme.successTitle.copyWith(
                   decoration: TextDecoration.none,
@@ -68,10 +68,10 @@ class SuccessPageState extends State<SuccessPage> {
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: 14.w),
                 child: Text(
-                  widget.isSend
-                      ? "We appreciate your contribution to recycling skincare packaging. Together, we're making a cleaner, greener future possible."
-                      : widget.isAdmin
-                          ? 'Thank you for confirming the recycling request and supporting our mission to reduce skincare packaging waste.'
+                  widget.isAdmin
+                      ? 'Thank you for confirming the recycling request and supporting our mission to reduce skincare packaging waste.'
+                      : widget.isSend
+                          ? "We appreciate your contribution to recycling skincare packaging. Together, we're making a cleaner, greener future possible."
                           : "We're excited to help you recycle your skincare packaging waste. Let's make a positive impact together!",
                   style: textTheme.label.copyWith(
                     decoration: TextDecoration.none,
@@ -95,12 +95,12 @@ class SuccessPageState extends State<SuccessPage> {
                     color: colors.red5,
                     borderRadius: BorderRadius.circular(50.r),
                   ),
-                    child: Text(
-                      '+${widget.point} points',
-                      style: textTheme.formName.copyWith(
-                        decoration: TextDecoration.none,
-                      ),
-                      textAlign: TextAlign.center,
+                  child: Text(
+                    '+${widget.point} points',
+                    style: textTheme.formName.copyWith(
+                      decoration: TextDecoration.none,
+                    ),
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ]

--- a/lib/cores/router/router.dart
+++ b/lib/cores/router/router.dart
@@ -4,6 +4,7 @@ import 'package:re_empties/cores/components/splash_screen.dart';
 import 'package:re_empties/cores/components/success_page.dart';
 import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/features/admin/view/admin_profile.dart';
+import 'package:re_empties/features/admin/view/admin_view.dart';
 import 'package:re_empties/features/admin/view/fill_order_id.view.dart';
 import 'package:re_empties/features/article/view/article_view.dart';
 import 'package:re_empties/features/authentication/views/login_view.dart';
@@ -48,8 +49,12 @@ setupRouter({required String initialRoute}) {
         builder: (context, state) => const RegisterPage(),
       ),
       GoRoute(
-          path: '/admin',
-          name: paths.admin,
+          path: '/adminView',
+          name: paths.adminView,
+          builder: (context, state) => AdminView()),
+      GoRoute(
+          path: '/adminProfile',
+          name: paths.adminProfile,
           builder: (context, state) => AdminProfile()),
       GoRoute(
           path: '/profile',

--- a/lib/cores/router/router.dart
+++ b/lib/cores/router/router.dart
@@ -6,6 +6,7 @@ import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/features/admin/view/admin_profile.dart';
 import 'package:re_empties/features/admin/view/admin_view.dart';
 import 'package:re_empties/features/admin/view/fill_order_id.view.dart';
+import 'package:re_empties/features/admin/view/transaction_detail_view.dart';
 import 'package:re_empties/features/article/view/article_view.dart';
 import 'package:re_empties/features/authentication/views/login_view.dart';
 import 'package:re_empties/features/authentication/views/register_view.dart';
@@ -99,7 +100,15 @@ setupRouter({required String initialRoute}) {
       GoRoute(
           path: '/fillDropID',
           name: paths.fillDropID,
-          builder: (context, state) => FillOrderID()),
+          builder: (context, state) {
+            final extra = state.extra as Map<String, dynamic>;
+
+            return FillOrderID(
+                adminID: extra['adminID'],
+                transactionData: extra['transactionData'],
+                point: extra['point'],
+                weight: extra['weight'],);
+          }),
       GoRoute(
           path: '/sendForm',
           name: paths.sendForm,
@@ -128,6 +137,18 @@ setupRouter({required String initialRoute}) {
               wasteLocation: extra['wasteLocation'] as Admin,
               isSend: extra['isSend'] ?? false,
               transactionId: extra['transactionID'],
+            );
+          }),
+      GoRoute(
+          path: '/transactionDetail',
+          name: paths.transactionDetail,
+          builder: (context, state) {
+            final extra = state.extra as Map<String, dynamic>;
+
+            return TransactionDetailView(
+              isSend: extra['isSend'] ?? false,
+              transactionID: extra['transactionID'],
+              transaction: extra['transaction'],
             );
           }),
     ],

--- a/lib/cores/router/router_constant.dart
+++ b/lib/cores/router/router_constant.dart
@@ -18,6 +18,7 @@ class _RouterPaths {
   final String sendForm = 'sendForm';
   final String dropPointDetail = 'dropPointDetail';
   final String fillDropID = 'fillDropID';
+  final String transactionDetail = 'transactionDetail';
 }
 
 final paths = _RouterPaths();

--- a/lib/cores/router/router_constant.dart
+++ b/lib/cores/router/router_constant.dart
@@ -8,7 +8,8 @@ class _RouterPaths {
   final String register = 'register';
   // final String test = 'test';
   final String success = 'success';
-  final String admin = 'admin';
+  final String adminView = 'adminView';
+  final String adminProfile = 'adminProfile';
   final String splash = 'splash';
   final String editProfile = 'editProfile';
   final String profile = 'profile';

--- a/lib/features/admin/view/admin_profile.dart
+++ b/lib/features/admin/view/admin_profile.dart
@@ -9,20 +9,21 @@ import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
 import 'package:re_empties/cores/template/view.dart';
+import 'package:re_empties/features/admin/viewModel/admin_profile_view_model.dart';
 import 'package:re_empties/features/admin/viewModel/admin_view_model.dart';
 
 class AdminProfile extends StatefulWidget {
   AdminProfile({super.key})
       : _viewModel =
-            ChangeNotifierProvider.autoDispose<AdminViewVM>(AdminViewVM.new);
+            ChangeNotifierProvider.autoDispose<AdminProfileVM>(AdminProfileVM.new);
 
-  final AutoDisposeChangeNotifierProvider<AdminViewVM> _viewModel;
+  final AutoDisposeChangeNotifierProvider<AdminProfileVM> _viewModel;
 
   @override
-  AdminViewState createState() => AdminViewState();
+  AdminProfileState createState() => AdminProfileState();
 }
 
-class AdminViewState extends State<AdminProfile> {
+class AdminProfileState extends State<AdminProfile> {
   @override
   Widget build(BuildContext context) {
     return BaseView(
@@ -40,7 +41,7 @@ class AdminViewState extends State<AdminProfile> {
     );
   }
 
-  Widget _buildScreen(BuildContext context, AdminViewVM vm) => Scaffold(
+  Widget _buildScreen(BuildContext context, AdminProfileVM vm) => Scaffold(
         backgroundColor: colors.bgColor,
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -71,7 +72,9 @@ class AdminViewState extends State<AdminProfile> {
           child: AppMainButton(
             state: ButtonState.primary,
             text: 'logout',
-            onPressed: () {},
+            onPressed: () {
+              vm.logout();
+            },
           ),
         ),
       );

--- a/lib/features/admin/view/admin_profile.dart
+++ b/lib/features/admin/view/admin_profile.dart
@@ -10,7 +10,6 @@ import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/admin/viewModel/admin_profile_view_model.dart';
-import 'package:re_empties/features/admin/viewModel/admin_view_model.dart';
 
 class AdminProfile extends StatefulWidget {
   AdminProfile({super.key})
@@ -55,12 +54,13 @@ class AdminProfileState extends State<AdminProfile> {
               ),
               Gap(10.h),
               Text(
-                'Waste Station Kemanggisan',
+                vm.adminName,
                 style: textTheme.title,
+                textAlign: TextAlign.center,
               ),
               Gap(10.h),
               Text(
-                'Jl. Ks. Tubun III Dalam No.32, RT.2/RW.3, Slipi, Kec. Palmerah, Kota Jakarta Barat, Daerah Khusus Ibukota Jakarta 11410',
+                vm.addressStation,
                 style: textTheme.label,
                 textAlign: TextAlign.center,
               ),

--- a/lib/features/admin/view/admin_view.dart
+++ b/lib/features/admin/view/admin_view.dart
@@ -91,7 +91,7 @@ class AdminViewState extends ConsumerState<AdminView> {
               ),
               Gap(16.h),
               Expanded(
-                child: vm.isLoading
+                child: vm.loading
                     ? Center(
                         child: CircularProgressIndicator(
                         color: colors.green2,

--- a/lib/features/admin/view/admin_view.dart
+++ b/lib/features/admin/view/admin_view.dart
@@ -52,7 +52,7 @@ class AdminViewState extends ConsumerState<AdminView> {
               height: 32.h,
             ),
           ),
-          Gap(8.w)
+          Gap(8.w),
         ],
       ),
       builder: _buildScreen,
@@ -70,13 +70,23 @@ class AdminViewState extends ConsumerState<AdminView> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  FilterButton(label: 'All', isSelected: true, onTap: () {}),
+                  FilterButton(
+                    label: 'All',
+                    isSelected: vm.selectedFilter == 'All',
+                    onTap: () => vm.setFilter('All'),
+                  ),
                   Gap(8.w),
                   FilterButton(
-                      label: 'Send Empties', isSelected: false, onTap: () {}),
+                    label: 'Send Empties',
+                    isSelected: vm.selectedFilter == 'Send',
+                    onTap: () => vm.setFilter('Send'),
+                  ),
                   Gap(8.w),
                   FilterButton(
-                      label: 'Drop Empties', isSelected: false, onTap: () {}),
+                    label: 'Drop Empties',
+                    isSelected: vm.selectedFilter == 'Drop',
+                    onTap: () => vm.setFilter('Drop'),
+                  ),
                 ],
               ),
               Gap(16.h),
@@ -86,7 +96,9 @@ class AdminViewState extends ConsumerState<AdminView> {
                         child: CircularProgressIndicator(
                         color: colors.green2,
                       ))
-                    : vm.transactions.isEmpty
+                    : vm.filteredTransactions.isEmpty ||
+                            vm.filteredTransactions.every((transaction) =>
+                                transaction.orderStatus == 'Verify')
                         ? Center(
                             child: Text(
                               "No transactions available",
@@ -94,13 +106,22 @@ class AdminViewState extends ConsumerState<AdminView> {
                             ),
                           )
                         : ListView.builder(
-                            itemCount: vm.transactions.length,
+                            itemCount: vm.filteredTransactions.length,
                             itemBuilder: (context, index) {
-                              final transaction = vm.transactions[index];
-                              return TransactionCard(
-                                name: transaction.name!,
-                                transactionType: transaction.transactionType,
-                                address: transaction.address!,
+                              final transaction =
+                                  vm.filteredTransactions[index];
+                              return Visibility(
+                                visible: transaction.orderStatus != 'Verify',
+                                child: TransactionCard(
+                                  name: transaction.name!,
+                                  transactionType: transaction.transactionType,
+                                  address: transaction.address!,
+                                  onTap: () => vm.goToTransactionDetailPage(
+                                    isSend:
+                                        transaction.transactionType == 'Send',
+                                    transaction: transaction,
+                                  ),
+                                ),
                               );
                             },
                           ),

--- a/lib/features/admin/view/admin_view.dart
+++ b/lib/features/admin/view/admin_view.dart
@@ -2,20 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/components/custom_app_bar.dart';
 import 'package:re_empties/cores/components/image_asset.dart';
 import 'package:re_empties/cores/components/tap_detector.dart';
 import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/admin/viewModel/admin_view_model.dart';
 import 'package:re_empties/features/admin/widget/filter_button.dart';
 import 'package:re_empties/features/admin/widget/transaction_card.dart';
 
-class AdminView extends StatefulWidget {
+class AdminView extends ConsumerStatefulWidget {
   AdminView({super.key})
-      : _viewModel = ChangeNotifierProvider.autoDispose<AdminViewVM>(AdminViewVM.new);
+      : _viewModel =
+            ChangeNotifierProvider.autoDispose<AdminViewVM>(AdminViewVM.new);
 
   final AutoDisposeChangeNotifierProvider<AdminViewVM> _viewModel;
 
@@ -23,7 +26,7 @@ class AdminView extends StatefulWidget {
   AdminViewState createState() => AdminViewState();
 }
 
-class AdminViewState extends State<AdminView> {
+class AdminViewState extends ConsumerState<AdminView> {
   @override
   Widget build(BuildContext context) {
     return BaseView(
@@ -39,7 +42,9 @@ class AdminViewState extends State<AdminView> {
         ),
         actions: [
           TapDetector(
-            onTap: (){},
+            onTap: () {
+              ctx.pushNamed(paths.adminProfile);
+            },
             child: ImageAsset(
               imagePath: images.adminProfile,
               fit: BoxFit.fill,
@@ -67,19 +72,38 @@ class AdminViewState extends State<AdminView> {
                 children: [
                   FilterButton(label: 'All', isSelected: true, onTap: () {}),
                   Gap(8.w),
-                  FilterButton(label: 'Send Empties', isSelected: false, onTap: () {}),
+                  FilterButton(
+                      label: 'Send Empties', isSelected: false, onTap: () {}),
                   Gap(8.w),
-                  FilterButton(label: 'Drop Empties', isSelected: false, onTap: () {}),
+                  FilterButton(
+                      label: 'Drop Empties', isSelected: false, onTap: () {}),
                 ],
               ),
               Gap(16.h),
               Expanded(
-                child: ListView.builder(
-                  itemCount: 5, // number of transactions
-                  itemBuilder: (context, index) {
-                    return const TransactionCard();
-                  },
-                ),
+                child: vm.isLoading
+                    ? Center(
+                        child: CircularProgressIndicator(
+                        color: colors.green2,
+                      ))
+                    : vm.transactions.isEmpty
+                        ? Center(
+                            child: Text(
+                              "No transactions available",
+                              style: textTheme.appbarTitle,
+                            ),
+                          )
+                        : ListView.builder(
+                            itemCount: vm.transactions.length,
+                            itemBuilder: (context, index) {
+                              final transaction = vm.transactions[index];
+                              return TransactionCard(
+                                name: transaction.name!,
+                                transactionType: transaction.transactionType,
+                                address: transaction.address!,
+                              );
+                            },
+                          ),
               ),
             ],
           ),

--- a/lib/features/admin/view/fill_order_id.view.dart
+++ b/lib/features/admin/view/fill_order_id.view.dart
@@ -8,12 +8,27 @@ import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/admin/viewModel/fill_order_id_view_model.dart';
+import 'package:re_empties/features/send_empties/model/transaction_model.dart';
 import 'package:re_empties/features/send_empties/widget/custom_pinput.dart';
 
 class FillOrderID extends ConsumerStatefulWidget {
-  FillOrderID({super.key})
-      : _viewModel =
-            ChangeNotifierProvider.autoDispose<FillOrderIdVM>(FillOrderIdVM.new);
+  final String adminID;
+  final TransactionModel transactionData;
+  final int weight;
+  final int point;
+  FillOrderID({
+    super.key,
+    required this.adminID,
+    required this.transactionData,
+    required this.weight,
+    required this.point,
+  }) : _viewModel = ChangeNotifierProvider.autoDispose<FillOrderIdVM>((ref) =>
+            FillOrderIdVM(ref,
+                adminID: adminID,
+                transactionData: transactionData,
+                point: point,
+                weight: weight
+                ));
 
   final AutoDisposeChangeNotifierProvider<FillOrderIdVM> _viewModel;
 
@@ -62,7 +77,11 @@ class FillOrderIdState extends ConsumerState<FillOrderID> {
           child: AppMainButton(
             state: ButtonState.primary,
             text: 'Verify Transaction',
-            onPressed: () {},
+            onPressed: () {
+              if (vm.formKey.currentState?.validate() ?? false) {
+                vm.saveTransaction();
+              } 
+            },
           ),
         ),
       );

--- a/lib/features/admin/view/transaction_detail_view.dart
+++ b/lib/features/admin/view/transaction_detail_view.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:re_empties/cores/components/button_main_app.dart';
+import 'package:re_empties/cores/components/custom_app_bar.dart';
+import 'package:re_empties/cores/components/image_asset.dart';
+import 'package:re_empties/cores/constant/colors.dart';
+import 'package:re_empties/cores/constant/image_path.dart';
+import 'package:re_empties/cores/constant/text_theme.dart';
+import 'package:re_empties/cores/template/view.dart';
+import 'package:re_empties/features/admin/viewModel/transaction_detail_view_model.dart';
+import 'package:re_empties/features/send_empties/model/transaction_model.dart';
+import 'package:re_empties/features/send_empties/widget/delivery_detail_container.dart';
+import 'package:re_empties/features/send_empties/widget/stepper.dart';
+
+class TransactionDetailView extends ConsumerStatefulWidget {
+  final TransactionModel transaction;
+  final String transactionID;
+  final bool isSend;
+  TransactionDetailView({
+    super.key,
+    required this.isSend,
+    required this.transaction,
+    required this.transactionID,
+  }) : _viewModel = ChangeNotifierProvider.autoDispose<TransactionDetailVM>(
+          (ref) => TransactionDetailVM(
+            ref,
+            transactionID: transactionID,
+          ),
+        );
+
+  final AutoDisposeChangeNotifierProvider<TransactionDetailVM> _viewModel;
+
+  @override
+  ConsumerState createState() => SendFormState();
+}
+
+class SendFormState extends ConsumerState<TransactionDetailView> {
+  @override
+  Widget build(BuildContext context) => BaseView(
+        provider: widget._viewModel,
+        appBar: (_) => CustomAppBar(
+          title: Text('Transaction Detail', style: textTheme.orderStationName),
+        ),
+        builder: _buildScreen,
+      );
+
+  Widget _buildScreen(BuildContext context, TransactionDetailVM vm) => Scaffold(
+        backgroundColor: colors.bgColor,
+        body: SingleChildScrollView(
+          physics: const ClampingScrollPhysics(),
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 20.w),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      widget.isSend ? 'Send Waste' : 'Drop Off Waste',
+                      style: textTheme.orderStationName,
+                    ),
+                    Text(
+                      widget.transactionID,
+                      style: textTheme.label.copyWith(color: colors.black),
+                    ),
+                  ],
+                ),
+                if (widget.isSend) ...[
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Delivery Partner',
+                        style: textTheme.formName,
+                      ),
+                      Text(widget.transaction.deliveryOption!,
+                          style: textTheme.label),
+                    ],
+                  ),
+                ],
+                Gap(10.h),
+                Row(
+                  children: [
+                    ImageAsset(
+                      imagePath: images.address,
+                      width: 38.w,
+                      height: 180.h,
+                    ),
+                    Gap(5.w),
+                    Expanded(
+                      child: Column(
+                        children: [
+                          DeliveryDetailContainer(
+                            isUser: true,
+                            name: vm.userFullName,
+                            phoneNumber: vm.userPhoneNum,
+                            address: vm.userAddress,
+                          ),
+                          Gap(15.h),
+                          DeliveryDetailContainer(
+                            isUser: false,
+                            name: vm.adminName,
+                            phoneNumber: vm.adminPhoneNum,
+                            address: vm.adminAddress,
+                          ),
+                        ],
+                      ),
+                    )
+                  ],
+                ),
+                Gap(30.h),
+                Text(
+                  'Waste Category',
+                  style: textTheme.title,
+                ),
+                Gap(5.h),
+                Divider(
+                  color: colors.gray4,
+                  height: 1.h,
+                ),
+                Gap(5.h),
+                ...vm.wasteCategories.map((category) {
+                  return Column(
+                    children: [
+                      WasteCategoryStepper(
+                        title: category.title,
+                        description: category.desc,
+                        imagePath: category.image,
+                        quantity: vm.wasteWeight[category.id] ?? 0,
+                        onIncrease: () => vm.increaseQuantity(category.id),
+                        onDecrease: () => vm.decreaseQuantity(category.id),
+                      ),
+                      Gap(10.h),
+                      Divider(color: colors.gray4, height: 1.h),
+                      Gap(10.h),
+                    ],
+                  );
+                }),
+                Gap(20.h),
+              ],
+            ),
+          ),
+        ),
+        bottomNavigationBar: Container(
+          color: colors.bgColor,
+          alignment: Alignment.center,
+          height: 70.h,
+          child: AppMainButton(
+            state: ButtonState.primary,
+            text: widget.isSend ? 'Verify Transaction' : 'Continue',
+            onPressed: () {
+              vm.saveTransaction(
+                  adminID: widget.transaction.adminID,
+                  transactionData: widget.transaction,
+                  isSend: widget.isSend);
+            },
+          ),
+        ),
+      );
+}

--- a/lib/features/admin/viewModel/admin_profile_view_model.dart
+++ b/lib/features/admin/viewModel/admin_profile_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
-
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
@@ -7,10 +8,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class AdminProfileVM extends BaseNotifier {
   AdminProfileVM(super.ref);
+  auth.User? currentAdmin;
+  String adminName = '';
+  String addressStation = '';
 
   @override
-  FutureOr<void> init() {
-
+  FutureOr<void> init() async {
+    isLoading = true;
+    await fetchAdminData();
+    isLoading = false;
   }
 
   Future<void> logout() async {
@@ -19,5 +25,24 @@ class AdminProfileVM extends BaseNotifier {
 
     ctx.goNamed(paths.login);
   }
-  
+
+  Future<void> fetchAdminData() async {
+    try {
+      currentAdmin = auth.FirebaseAuth.instance.currentUser;
+      if (currentAdmin != null) {
+        DocumentSnapshot userDoc = await FirebaseFirestore.instance
+            .collection('admin')
+            .doc(currentAdmin!.uid)
+            .get();
+
+        if (userDoc.exists) {
+          adminName = userDoc['stationName'];
+          addressStation = userDoc['addressStation'];
+          notifyListeners();
+        }
+      }
+    } catch (e) {
+      print('Error fetching user data: $e');
+    }
+  }
 }

--- a/lib/features/admin/viewModel/admin_profile_view_model.dart
+++ b/lib/features/admin/viewModel/admin_profile_view_model.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
+import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class AdminProfileVM extends BaseNotifier {
   AdminProfileVM(super.ref);
@@ -8,6 +11,13 @@ class AdminProfileVM extends BaseNotifier {
   @override
   FutureOr<void> init() {
 
+  }
+
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+
+    ctx.goNamed(paths.login);
   }
   
 }

--- a/lib/features/admin/viewModel/admin_view_model.dart
+++ b/lib/features/admin/viewModel/admin_view_model.dart
@@ -1,13 +1,95 @@
 import 'dart:async';
 
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart' as auth;
 import 'package:re_empties/cores/template/notifer.dart';
+import 'package:re_empties/features/send_empties/model/transaction_model.dart';
 
 class AdminViewVM extends BaseNotifier {
   AdminViewVM(super.ref);
+  auth.User? currentAdmin;
+  List<TransactionModel> transactions = [];
+  // auth.User? currentUser;
+  String userFullName = '';
+  String userEmail = '';
+  String userPhoneNum = '';
+  String userAddress = '';
 
   @override
   FutureOr<void> init() {
-
+    isLoading = true;
+    fetchAdminTransactionData();
+    print('uhuy');
+    isLoading = false;
   }
-  
+
+  Future<void> fetchUserData(String currentUserUid) async {
+    try {
+        DocumentSnapshot userDoc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(currentUserUid)
+            .get();
+
+        if (userDoc.exists) {
+          userFullName = userDoc['userName'] ?? '';
+          userEmail = userDoc['userEmail'] ?? '';
+          userPhoneNum = userDoc['userPhoneNumber'] ?? '';
+          userAddress = userDoc['userAddress'] ?? '';
+          notifyListeners();
+        }
+    } catch (e) {
+      print('Error fetching user data: $e');
+    }
+  }
+
+  Future<void> fetchAdminTransactionData() async {
+  try {
+    currentAdmin = auth.FirebaseAuth.instance.currentUser;
+    if (currentAdmin != null) {
+      QuerySnapshot querySnapshot = await FirebaseFirestore.instance
+          .collection('admin')
+          .doc(currentAdmin!.uid)
+          .collection('transactions')
+          .get();
+
+      // Mapping transactions
+      List<TransactionModel> tempTransactions = [];
+      for (var doc in querySnapshot.docs) {
+        TransactionModel transaction = TransactionModel.fromFirestore(doc.data() as Map<String, dynamic>);
+
+        // Ambil userAddress menggunakan fetchUserData
+        if (transaction.userID.isNotEmpty) {
+          await fetchUserData(transaction.userID);
+          transaction = TransactionModel(
+            userID: transaction.userID,
+            adminID: transaction.adminID,
+            cardboardWeight: transaction.cardboardWeight,
+            currentLocationLat: transaction.currentLocationLat,
+            currentLocationLong: transaction.currentLocationLong,
+            dateTime: transaction.dateTime,
+            deliveryFee: transaction.deliveryFee,
+            deliveryOption: transaction.deliveryOption,
+            earnPoints: transaction.earnPoints,
+            glassWeight: transaction.glassWeight,
+            orderStatus: transaction.orderStatus,
+            paymentType: transaction.paymentType,
+            plasticWeight: transaction.plasticWeight,
+            totalWeight: transaction.totalWeight,
+            transactionType: transaction.transactionType,
+            dropID: transaction.dropID,
+            name: userFullName,
+            address: userAddress,
+          );
+        }
+        tempTransactions.add(transaction);
+      }
+
+      transactions = tempTransactions;
+      notifyListeners();
+    }
+  } catch (e) {
+    print('Error fetching transaction admin data: $e');
+  }
+}
+
 }

--- a/lib/features/admin/viewModel/admin_view_model.dart
+++ b/lib/features/admin/viewModel/admin_view_model.dart
@@ -18,6 +18,7 @@ class AdminViewVM extends BaseNotifier with CustomToastMixin {
   String userPhoneNum = '';
   String userAddress = '';
   late Admin adminData;
+  bool loading = false;
 
   @override
   FutureOr<void> init() {
@@ -73,7 +74,6 @@ class AdminViewVM extends BaseNotifier with CustomToastMixin {
   String get selectedFilter => _selectedFilter;
   List<TransactionModel> get filteredTransactions {
     if (_selectedFilter == 'All') {
-      // print(transactions.toList());
       return transactions;
     }
     return transactions.where((transaction) {
@@ -81,10 +81,20 @@ class AdminViewVM extends BaseNotifier with CustomToastMixin {
     }).toList();
   }
 
-  void setFilter(String filter) {
+  void setFilter(String filter) async {
     _selectedFilter = filter;
-    _filteredTransactions = filteredTransactions;
+    loading = true;
     notifyListeners();
+
+    try {
+      await fetchAdminTransactionData(); // Fetch ulang data dari Firestore
+      _filteredTransactions = filteredTransactions; // Terapkan filter
+    } catch (e) {
+      print('Error fetching data during filter: $e');
+    } finally {
+      loading = false;
+      notifyListeners(); // Perbarui UI
+    }
   }
 
   Future<void> fetchAdminTransactionData() async {

--- a/lib/features/admin/viewModel/admin_view_model.dart
+++ b/lib/features/admin/viewModel/admin_view_model.dart
@@ -1,95 +1,148 @@
 import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/components/custom_toast_mixin.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
+import 'package:re_empties/features/send_empties/model/location_model.dart';
 import 'package:re_empties/features/send_empties/model/transaction_model.dart';
 
-class AdminViewVM extends BaseNotifier {
+class AdminViewVM extends BaseNotifier with CustomToastMixin {
   AdminViewVM(super.ref);
   auth.User? currentAdmin;
   List<TransactionModel> transactions = [];
-  // auth.User? currentUser;
   String userFullName = '';
   String userEmail = '';
   String userPhoneNum = '';
   String userAddress = '';
+  late Admin adminData;
 
   @override
   FutureOr<void> init() {
     isLoading = true;
     fetchAdminTransactionData();
-    print('uhuy');
     isLoading = false;
   }
 
   Future<void> fetchUserData(String currentUserUid) async {
     try {
-        DocumentSnapshot userDoc = await FirebaseFirestore.instance
-            .collection('users')
-            .doc(currentUserUid)
-            .get();
+      DocumentSnapshot userDoc = await FirebaseFirestore.instance
+          .collection('users')
+          .doc(currentUserUid)
+          .get();
 
-        if (userDoc.exists) {
-          userFullName = userDoc['userName'] ?? '';
-          userEmail = userDoc['userEmail'] ?? '';
-          userPhoneNum = userDoc['userPhoneNumber'] ?? '';
-          userAddress = userDoc['userAddress'] ?? '';
-          notifyListeners();
-        }
+      if (userDoc.exists) {
+        userFullName = userDoc['userName'] ?? '';
+        userEmail = userDoc['userEmail'] ?? '';
+        userPhoneNum = userDoc['userPhoneNumber'] ?? '';
+        userAddress = userDoc['userAddress'] ?? '';
+        notifyListeners();
+      }
     } catch (e) {
       print('Error fetching user data: $e');
     }
   }
 
-  Future<void> fetchAdminTransactionData() async {
-  try {
-    currentAdmin = auth.FirebaseAuth.instance.currentUser;
-    if (currentAdmin != null) {
-      QuerySnapshot querySnapshot = await FirebaseFirestore.instance
+  Future<void> fetchAdminData(String currentAdminUid) async {
+    try {
+      DocumentSnapshot adminDoc = await FirebaseFirestore.instance
           .collection('admin')
-          .doc(currentAdmin!.uid)
-          .collection('transactions')
+          .doc(currentAdminUid)
           .get();
 
-      // Mapping transactions
-      List<TransactionModel> tempTransactions = [];
-      for (var doc in querySnapshot.docs) {
-        TransactionModel transaction = TransactionModel.fromFirestore(doc.data() as Map<String, dynamic>);
-
-        // Ambil userAddress menggunakan fetchUserData
-        if (transaction.userID.isNotEmpty) {
-          await fetchUserData(transaction.userID);
-          transaction = TransactionModel(
-            userID: transaction.userID,
-            adminID: transaction.adminID,
-            cardboardWeight: transaction.cardboardWeight,
-            currentLocationLat: transaction.currentLocationLat,
-            currentLocationLong: transaction.currentLocationLong,
-            dateTime: transaction.dateTime,
-            deliveryFee: transaction.deliveryFee,
-            deliveryOption: transaction.deliveryOption,
-            earnPoints: transaction.earnPoints,
-            glassWeight: transaction.glassWeight,
-            orderStatus: transaction.orderStatus,
-            paymentType: transaction.paymentType,
-            plasticWeight: transaction.plasticWeight,
-            totalWeight: transaction.totalWeight,
-            transactionType: transaction.transactionType,
-            dropID: transaction.dropID,
-            name: userFullName,
-            address: userAddress,
-          );
-        }
-        tempTransactions.add(transaction);
+      if (adminDoc.exists) {
+        adminData =
+            Admin.fromFirestore(adminDoc.data() as Map<String, dynamic>);
+        notifyListeners();
       }
-
-      transactions = tempTransactions;
-      notifyListeners();
+    } catch (e) {
+      print('Error fetching admin data: $e');
     }
-  } catch (e) {
-    print('Error fetching transaction admin data: $e');
   }
-}
 
+  String? getCurrentAdminId() {
+    final admin = FirebaseAuth.instance.currentUser;
+    return admin?.uid;
+  }
+
+  String _selectedFilter = 'All';
+  List<TransactionModel> _filteredTransactions = [];
+
+  String get selectedFilter => _selectedFilter;
+  List<TransactionModel> get filteredTransactions {
+    if (_selectedFilter == 'All') {
+      // print(transactions.toList());
+      return transactions;
+    }
+    return transactions.where((transaction) {
+      return transaction.transactionType == _selectedFilter;
+    }).toList();
+  }
+
+  void setFilter(String filter) {
+    _selectedFilter = filter;
+    _filteredTransactions = filteredTransactions;
+    notifyListeners();
+  }
+
+  Future<void> fetchAdminTransactionData() async {
+    try {
+      currentAdmin = auth.FirebaseAuth.instance.currentUser;
+      if (currentAdmin != null) {
+        QuerySnapshot querySnapshot = await FirebaseFirestore.instance
+            .collection('admin')
+            .doc(currentAdmin!.uid)
+            .collection('transactions')
+            .get();
+
+        // Mapping transactions
+        List<TransactionModel> tempTransactions = [];
+        for (var doc in querySnapshot.docs) {
+          TransactionModel transaction = TransactionModel.fromFirestore(
+              doc.data() as Map<String, dynamic>, doc.id);
+
+          // print(
+          //     'Transaction ID: ${transaction.transactionId}, Type: ${transaction.transactionType}');
+
+          // Assign the document ID (transactionId)
+          transaction = transaction.copyWith(transactionId: doc.id);
+
+          // Fetch user data for address
+          if (transaction.userID.isNotEmpty) {
+            await fetchUserData(transaction.userID);
+            transaction = transaction.copyWith(
+              name: userFullName,
+              address: userAddress,
+            );
+          }
+          tempTransactions.add(transaction);
+        }
+
+        transactions = tempTransactions;
+        notifyListeners();
+      }
+    } catch (e) {
+      print('Error fetching transaction admin data: $e');
+    }
+  }
+
+  late bool send;
+
+  void goToTransactionDetailPage({
+    required bool? isSend,
+    required TransactionModel transaction,
+  }) async {
+    send = isSend ?? false;
+
+    await fetchAdminData(getCurrentAdminId()!);
+
+    ctx.pushNamed(paths.transactionDetail, extra: <String, dynamic>{
+      'admin': adminData,
+      'transaction': transaction,
+      'isSend': isSend,
+      'transactionID': transaction.transactionId,
+    });
+  }
 }

--- a/lib/features/admin/viewModel/fill_order_id_view_model.dart
+++ b/lib/features/admin/viewModel/fill_order_id_view_model.dart
@@ -1,35 +1,92 @@
 import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/components/custom_toast_mixin.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
+import 'package:re_empties/features/send_empties/model/transaction_model.dart';
 
-class FillOrderIdVM extends BaseNotifier {
+class FillOrderIdVM extends BaseNotifier with CustomToastMixin{
+  final String adminID;
+  final TransactionModel transactionData;
+  final int weight;
+  final int point;
+
   final formKey = GlobalKey<FormState>();
   bool showError = false;
   String otp = ''; // The generated OTP code
 
-  FillOrderIdVM(super.ref,);
-
+  FillOrderIdVM(
+    super.ref, {
+    required this.adminID,
+    required this.transactionData,
+    required this.weight,
+    required this.point,
+  });
 
   @override
   FutureOr<void> init() {
+    print(transactionData.transactionId);
   }
 
   /// Handle OTP submission
   onFilled(String otpInput) {
-    // showError = false;
-
-    // // Simulate success
-    // otp = otpInput;
-    // print("OTP Verified: $otpInput");
-    // showError = false;
-    // notifyListeners();
+    if (otpInput == transactionData.dropID) {
+      // OTP matches
+      // showCustomToast('Success! Transaction verified');
+      showError = false; // Reset error
+    } else {
+      // OTP does not match
+      // showCustomToast('DropID does not match', isError: true);
+      showError = true;
+      notifyListeners(); // Trigger UI update to show error
+    }
   }
 
   String? getErrorText() {
-    if (showError) return ' Kode yang Anda masukkan salah';
+    if (showError) return 'DropID does not match. Please fill the DropID correctly';
     return null;
   }
 
+  void saveTransaction() async {
+    try {
+      // Validasi form
+      if (showError) return;
+
+      // Data untuk disimpan ke Firestore
+      final transactionUpdateData = {
+        'earnPoints': point,
+        'orderStatus': 'Verify',
+        'totalWeight': weight,
+      };
+
+      // Dapatkan referensi dokumen transaksi
+      final transactionDocRef = FirebaseFirestore.instance
+          .collection('admin')
+          .doc(adminID)
+          .collection('transactions')
+          .doc(transactionData.transactionId);
+
+      // Update dokumen transaksi
+      await transactionDocRef.update(transactionUpdateData);
+
+      // Navigasi berdasarkan kondisi `isSend`
+      // if (!isSend) {
+      //   ctx.pushNamed(paths.fillDropID);
+      // } else {
+        showCustomToast('Transaction verified successfully');
+        ctx.pushNamed(paths.success, extra: <String, dynamic>{
+          'isSend': false,
+          'isAdmin': true,
+          'point': point
+        });
+      // }
+    } catch (e) {
+      // Tangani error dan tampilkan notifikasi error
+      showCustomToast('Error verify transaction: $e', isError: true);
+    }
+  }
 
   @override
   void dispose() {

--- a/lib/features/admin/viewModel/transaction_detail_view_model.dart
+++ b/lib/features/admin/viewModel/transaction_detail_view_model.dart
@@ -1,0 +1,211 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/components/custom_toast_mixin.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
+import 'package:re_empties/cores/template/notifer.dart';
+import 'package:re_empties/features/send_empties/model/transaction_model.dart';
+import 'package:re_empties/features/send_empties/model/waste_category.dart';
+import 'package:firebase_auth/firebase_auth.dart' as auth;
+
+class TransactionDetailVM extends BaseNotifier with CustomToastMixin {
+  final String transactionID;
+
+  TransactionDetailVM(
+    super.ref, {
+    required this.transactionID,
+  });
+
+  List<WasteCategoryModel> wasteCategories = [];
+
+  auth.User? currentAdmin;
+  String userFullName = '';
+  String userPhoneNum = '';
+  String userAddress = '';
+  String userID = '';
+
+  String adminName = '';
+  String adminPhoneNum = '';
+  String adminAddress = '';
+  String adminID = '';
+
+  // Properti terkait quantity
+  Map<String, int> wasteWeight = {};
+
+  Future<void> fetchUserData() async {
+    try {
+      currentAdmin = auth.FirebaseAuth.instance.currentUser;
+      if (currentAdmin != null) {
+        DocumentSnapshot adminDoc = await FirebaseFirestore.instance
+            .collection('admin')
+            .doc(currentAdmin!.uid)
+            .collection('transactions')
+            .doc(transactionID)
+            .get();
+
+        if (adminDoc.exists) {
+          userID = adminDoc['userID'] ?? '';
+          // print(userID);
+          await fetchUserData2(userID);
+          notifyListeners();
+        }
+      }
+    } catch (e) {
+      showCustomToast('Error fetching user data: $e', isError: true);
+    }
+  }
+
+  Future<void> fetchAdminData() async {
+    try {
+      currentAdmin = auth.FirebaseAuth.instance.currentUser;
+      if (currentAdmin != null) {
+        DocumentSnapshot userDoc = await FirebaseFirestore.instance
+            .collection('admin')
+            .doc(currentAdmin!.uid)
+            .get();
+
+        if (userDoc.exists) {
+          adminID = userDoc.id;
+          adminName = userDoc['adminName'];
+          adminPhoneNum = userDoc['adminPhone'];
+          adminAddress = userDoc['addressStation'];
+          notifyListeners();
+        }
+      }
+    } catch (e) {
+      showCustomToast('Error fetching user data: $e', isError: true);
+    }
+  }
+
+  Future<void> fetchUserData2(String id) async {
+    try {
+      DocumentSnapshot userDoc =
+          await FirebaseFirestore.instance.collection('users').doc(id).get();
+
+      if (userDoc.exists) {
+        userFullName = userDoc['userName'] ?? '';
+        userPhoneNum = userDoc['userPhoneNumber'] ?? '';
+        userAddress = userDoc['userAddress'] ?? '';
+        notifyListeners();
+      }
+    } catch (e) {
+      showCustomToast('Error fetching user data: $e', isError: true);
+    }
+  }
+
+  Future<void> fetchWasteCategories() async {
+    final wasteCategoryCollection =
+        FirebaseFirestore.instance.collection('wasteCategory');
+    final snapshot = await wasteCategoryCollection.get();
+
+    wasteCategories = snapshot.docs
+        .map((doc) =>
+            WasteCategoryModel.fromFirestore(doc.data(), docId: doc.id))
+        .toList();
+    notifyListeners();
+  }
+
+  // Fungsi untuk mengatur kuantitas awal
+  void initializeWasteQuantities(List<WasteCategoryModel> categories) {
+    for (var category in categories) {
+      wasteWeight[category.id] = 1; // Default quantity untuk setiap kategori
+    }
+    notifyListeners();
+  }
+
+  // Fungsi untuk meningkatkan kuantitas
+  void increaseQuantity(String categoryId) {
+    if (wasteWeight.containsKey(categoryId)) {
+      wasteWeight[categoryId] = (wasteWeight[categoryId] ?? 0) + 1;
+      notifyListeners();
+    }
+  }
+
+  // Fungsi untuk mengurangi kuantitas
+  void decreaseQuantity(String categoryId) {
+    if (wasteWeight.containsKey(categoryId) &&
+        (wasteWeight[categoryId] ?? 0) > 0) {
+      wasteWeight[categoryId] = (wasteWeight[categoryId] ?? 0) - 1;
+      notifyListeners();
+    }
+  }
+
+  bool validateForm() {
+    int totalQty = 0;
+    for (var quantity in wasteWeight.values) {
+      totalQty += quantity;
+    }
+
+    if (totalQty < 1) {
+      showCustomToast('Waste categories must at least 1 kg', isError: true);
+      return false;
+    }
+
+    return true;
+  }
+
+  void saveTransaction({
+    required String adminID,
+    required TransactionModel transactionData,
+    required bool isSend,
+  }) async {
+    try {
+      // Validasi form
+      if (!validateForm()) return;
+
+       // Hitung total berat dan poin
+      final weight = wasteWeight.values.fold(0, (sum, qty) => sum + qty);
+      final point = transactionData.totalWastePcs * 100;
+
+      if (!isSend) {
+        ctx.pushNamed(paths.fillDropID, extra: <String, dynamic>{
+          'adminID': adminID,
+          'weight': weight,
+          'point': point,
+          'transactionData': transactionData,          
+        });
+        return;
+      }
+
+      // Data untuk disimpan ke Firestore
+      final transactionUpdateData = {
+        'earnPoints': point,
+        'orderStatus': 'Verify',
+        'totalWeight': weight,
+      };
+
+      // Dapatkan referensi dokumen transaksi
+      final transactionDocRef = FirebaseFirestore.instance
+          .collection('admin')
+          .doc(adminID)
+          .collection('transactions')
+          .doc(transactionID);
+
+      // Update dokumen transaksi
+      await transactionDocRef.update(transactionUpdateData);
+
+      // Navigasi berdasarkan kondisi `isSend`
+      // if (!isSend) {
+      //   ctx.pushNamed(paths.fillDropID);
+      // } else {
+        showCustomToast('Transaction verified successfully');
+        ctx.pushNamed(paths.success, extra: <String, dynamic>{
+          'isSend': isSend,
+          'isAdmin': true,
+          'point': point
+        });
+      // }
+    } catch (e) {
+      // Tangani error dan tampilkan notifikasi error
+      showCustomToast('Error verify transaction: $e', isError: true);
+    }
+  }
+
+  @override
+  FutureOr<void> init() async {
+    await fetchWasteCategories();
+    await fetchUserData();
+    await fetchAdminData();
+    initializeWasteQuantities(wasteCategories);
+  }
+}

--- a/lib/features/admin/widget/transaction_card.dart
+++ b/lib/features/admin/widget/transaction_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:re_empties/cores/components/tap_detector.dart';
 import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
 
@@ -7,9 +8,11 @@ class TransactionCard extends StatelessWidget {
   final String name;
   final String transactionType;
   final String address;
+  final VoidCallback onTap;
 
   const TransactionCard(
       {super.key,
+      required this.onTap,
       required this.name,
       required this.transactionType,
       required this.address});
@@ -34,7 +37,9 @@ class TransactionCard extends StatelessWidget {
             maxLines: 3,
             overflow: TextOverflow.ellipsis,
           ),
-          trailing: Icon(Icons.arrow_forward_ios, color: colors.green1),
+          trailing: TapDetector(
+              onTap: onTap,
+              child: Icon(Icons.arrow_forward_ios, color: colors.green1)),
         ),
       ),
     );

--- a/lib/features/admin/widget/transaction_card.dart
+++ b/lib/features/admin/widget/transaction_card.dart
@@ -4,7 +4,15 @@ import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
 
 class TransactionCard extends StatelessWidget {
-  const TransactionCard({super.key});
+  final String name;
+  final String transactionType;
+  final String address;
+
+  const TransactionCard(
+      {super.key,
+      required this.name,
+      required this.transactionType,
+      required this.address});
 
   @override
   Widget build(BuildContext context) {
@@ -17,20 +25,12 @@ class TransactionCard extends StatelessWidget {
           border: Border.all(color: colors.green1, width: 2),
         ),
         child: ListTile(
-          title: Row(
-            children: [
-              Text(
-                'Nama - ',
-                style: textTheme.title,
-              ),
-              Text(
-                'Tipe Orderan',
-                style: textTheme.title,
-              ),
-            ],
+          title: Text(
+            '$name - $transactionType',
+            style: textTheme.title,
           ),
           subtitle: Text(
-            'Jl. Raya Kb. Jeruk No.27, RT.1/RW.9, Kemanggisan, Kec. Palmerah, Kota Jakarta Barat, Daerah Khusus Ibukota Jakarta 11530',
+            address,
             maxLines: 3,
             overflow: TextOverflow.ellipsis,
           ),

--- a/lib/features/authentication/viewmodel/login_viewmodel.dart
+++ b/lib/features/authentication/viewmodel/login_viewmodel.dart
@@ -30,7 +30,6 @@ class LoginVM extends BaseFormNotifier<LoginModel> with FormValidatorMixin {
         );
 
         SharedPreferences preferences = await SharedPreferences.getInstance();
-        await preferences.setBool('isLoggedIn', true);
         await preferences.setString('userId', userCredential.user?.uid ?? '');
         print('User Logged in: ${userCredential.user?.uid}');
 
@@ -45,30 +44,22 @@ class LoginVM extends BaseFormNotifier<LoginModel> with FormValidatorMixin {
 
           if (adminDoc.exists) {
             print("Admin Logged in : ${userCredential.user?.uid}");
-            context.go('/admin');
+            await preferences.setBool('isAdminLoggedIn', true);
+            ctx.goNamed(paths.adminView);
             return;
           } else {
             print("Admin not found in the database.");
           }
         }
 
-        context.go('/home');
+        ctx.goNamed(paths.home);
+        await preferences.setBool('isUserLoggedIn', true);
       } on FirebaseAuthException catch (e) {
         // Tangani kesalahan login
         print('Failed with error code: ${e.code}');
         print(e.message);
       }
     }
-  }
-
-  Future<void> logout(BuildContext context) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-
-    form.email.controller.clear();
-    form.password.controller.clear();
-
-    ctx.pushReplacement('/login');
   }
 
   @override

--- a/lib/features/authentication/viewmodel/register_viewmodel.dart
+++ b/lib/features/authentication/viewmodel/register_viewmodel.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/src/change_notifier_provider.dart';
 import 'package:go_router/go_router.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 
 import 'package:re_empties/cores/template/form_notifier.dart';
 import 'package:re_empties/cores/template/form_validator.dart';
@@ -45,13 +46,9 @@ class RegisterVM extends BaseFormNotifier<RegisterModel>
             .doc(userCredential.user?.uid)
             .set(user.toMap());
 
-        // shared preferences
-        SharedPreferences preferences = await SharedPreferences.getInstance();
-        await preferences.setBool('isRegisterIn', true);
-        await preferences.setString('userId', userCredential.user?.uid ?? '');
         print('User Registered: ${userCredential.user?.uid}');
 
-        context.go('/home');
+        ctx.goNamed(paths.login);
       } on FirebaseAuthException catch (e) {
         // Tangani kesalahan login
         print('Failed with error code: ${e.code}');

--- a/lib/features/authentication/views/login_view.dart
+++ b/lib/features/authentication/views/login_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:re_empties/cores/components/button_main_app.dart';
 import 'package:re_empties/cores/components/form_text_field.dart';
@@ -10,6 +11,7 @@ import 'package:re_empties/cores/components/tap_detector.dart';
 import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/authentication/viewmodel/login_viewmodel.dart';
 import 'package:re_empties/features/authentication/views/register_view.dart';
@@ -29,6 +31,7 @@ class LoginPage extends StatelessWidget {
       );
 
   Widget _buildScreen(BuildContext context, LoginVM vm) => Scaffold(
+    resizeToAvoidBottomInset: false,
         body: Stack(
           children: [
             ImageAsset(
@@ -37,8 +40,9 @@ class LoginPage extends StatelessWidget {
               width: double.infinity,
               fit: BoxFit.cover,
             ),
-            Padding(
+            SingleChildScrollView(
               padding: EdgeInsets.symmetric(horizontal: 40.w, vertical: 100.h),
+              physics: const ClampingScrollPhysics(),
               child: Column(
                 children: [
                   Column(
@@ -95,22 +99,19 @@ class LoginPage extends StatelessWidget {
                     children: [
                       Text(
                         "Don't have an account?",
-                        style: textTheme.subtitle.copyWith(fontSize: 16),
+                        style: textTheme.subtitle.copyWith(fontSize: 15.sp),
                         textAlign: TextAlign.center,
                       ),
                       Gap(5.w),
                       TapDetector(
                         onTap: () {
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (context) => const RegisterPage()));
+                          ctx.goNamed(paths.register);
                         },
                         child: Text(
                           "Register Here",
                           style: textTheme.subtitle.copyWith(
                               color: colors.textButton,
-                              fontSize: 16,
+                              fontSize: 16.sp,
                               fontWeight: FontWeight.w700),
                           textAlign: TextAlign.center,
                         ),

--- a/lib/features/authentication/views/register_view.dart
+++ b/lib/features/authentication/views/register_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/src/size_extension.dart';
 import 'package:gap/gap.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:re_empties/cores/components/button_main_app.dart';
 import 'package:re_empties/cores/components/form_text_field.dart';
@@ -9,6 +10,7 @@ import 'package:re_empties/cores/components/tap_detector.dart';
 import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
+import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/authentication/viewmodel/register_viewmodel.dart';
 import 'package:re_empties/features/authentication/views/login_view.dart';
@@ -122,22 +124,15 @@ class RegisterPage extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      const Text(
+                      Text(
                         "Already have an account? ",
-                        style: TextStyle(
-                          color: Colors.black,
-                          fontSize: 15.0,
-                          fontWeight: FontWeight.w400,
-                        ),
+                        style: textTheme.subtitle.copyWith(fontSize: 15.sp),
                         textAlign: TextAlign.center,
                       ),
                       Gap(5.w),
                       TapDetector(
                         onTap: () {
-                          Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                  builder: (context) => const LoginPage()));
+                          ctx.goNamed(paths.login);
                         },
                         child: Text(
                           "Login Here",

--- a/lib/features/home/view model/dashboard_viewmodel.dart
+++ b/lib/features/home/view model/dashboard_viewmodel.dart
@@ -11,20 +11,13 @@ class DashboardVM extends BaseNotifier {
 
   Future<void> checkLoginStatus(BuildContext context) async {
     final prefs = await SharedPreferences.getInstance();
-    bool isLoggedIn = prefs.getBool('isLoggedIn') ?? false;
+    bool isUserLoggedIn = prefs.getBool('isUserLoggedIn') ?? false;
 
-    if (!isLoggedIn) {
+    if (!isUserLoggedIn) {
       context.go('/login');
     }
   }
-
-  Future<void> logout(BuildContext context) async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.clear();
-
-    ctx.pushReplacement('/login');
-  }
-
+  
   void goToIntroPage({bool? isSend}) {
     ctx.pushNamed(paths.intro, extra: isSend);
   }

--- a/lib/features/home/view/dashboard_view.dart
+++ b/lib/features/home/view/dashboard_view.dart
@@ -107,12 +107,6 @@ class _DashboardViewState extends ConsumerState<DashboardView>
                       ),
                     ),
                     ArticlePreviewHome(),
-                    ElevatedButton(
-                      onPressed: () {
-                        vm.logout(context);
-                      },
-                      child: Text('Logout'),
-                    ),
                   ],
                 ),
               ),

--- a/lib/features/profile/view model/edit_profile_view_model.dart
+++ b/lib/features/profile/view model/edit_profile_view_model.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/form_notifier.dart';

--- a/lib/features/profile/view model/profile_view_model.dart
+++ b/lib/features/profile/view model/profile_view_model.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' as auth;
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ProfileVM extends BaseNotifier {
   ProfileVM(super.ref);
@@ -19,6 +18,15 @@ class ProfileVM extends BaseNotifier {
   Future<void> init() async {
     await fetchUserData();
   }
+  
+
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.clear();
+
+    if (ctx.mounted) ctx.goNamed(paths.login);
+  }
+
 
   Future<void> fetchUserData() async {
     try {

--- a/lib/features/profile/view/edit_profile.dart
+++ b/lib/features/profile/view/edit_profile.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/components/button_main_app.dart';
 import 'package:re_empties/cores/components/custom_app_bar.dart';
 import 'package:re_empties/cores/components/form_text_field.dart';

--- a/lib/features/profile/view/profile_view.dart
+++ b/lib/features/profile/view/profile_view.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 import 'package:re_empties/cores/components/banner_home.dart';
 import 'package:re_empties/cores/components/button_main_app.dart';
 import 'package:re_empties/cores/components/hidden_app_bar.dart';
@@ -10,7 +9,6 @@ import 'package:re_empties/cores/components/points_card_home.dart';
 import 'package:re_empties/cores/constant/colors.dart';
 import 'package:re_empties/cores/constant/image_path.dart';
 import 'package:re_empties/cores/constant/text_theme.dart';
-import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/view.dart';
 import 'package:re_empties/features/profile/view%20model/profile_view_model.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -113,7 +111,7 @@ class ProfileViewState extends State<ProfileView> {
                   style: textTheme.title,
                 ),
                 HomePointsCard(
-                  onTap: () => context.push('/admin'), // change later
+                  onTap: () {},
                 ),
                 Gap(16.h),
               ],
@@ -125,7 +123,9 @@ class ProfileViewState extends State<ProfileView> {
           child: AppMainButton(
             state: ButtonState.primary,
             text: 'logout',
-            onPressed: () {},
+            onPressed: () {
+              vm.logout();
+            },
           ),
         ),
       );

--- a/lib/features/send_empties/model/location_model.dart
+++ b/lib/features/send_empties/model/location_model.dart
@@ -40,6 +40,19 @@ class Admin {
     required this.openHours,
     this.distance,
   });
+
+  factory Admin.fromFirestore(Map<String, dynamic> json) {
+    return Admin(
+      id: '',
+      addressStation: json['addressStation'],
+      adminPhone: json['adminPhone'],
+      stationName: json['stationName'],
+      wasteLocation: json['wasteLocation'],
+      openHours: json['openHours'],
+      adminName: json['adminName'],
+      adminEmail: json['adminEmail'],
+    );
+  }
 }
 
 

--- a/lib/features/send_empties/model/transaction_model.dart
+++ b/lib/features/send_empties/model/transaction_model.dart
@@ -1,64 +1,121 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class TransactionModel {
+  final String transactionId; // Tambahkan transactionId
   final String userID;
   final String adminID;
-  final int cardboardWeight;
+  final int? cardboardWeight;
   final double currentLocationLat;
   final double currentLocationLong;
   final DateTime dateTime;
-  final String? deliveryFee;
+  final int deliveryFee;
   final String? deliveryOption;
   final int earnPoints;
-  final int glassWeight;
+  final int? glassWeight;
   final String orderStatus;
   final String? paymentType;
-  final int plasticWeight;
-  final int totalWeight;
+  final int? plasticWeight;
+  final int? totalWeight;
   final String transactionType;
   final String? dropID;
   final String? name;
   final String? address;
+  final int totalWastePcs;
 
   TransactionModel({
+    this.transactionId = '', // Default kosong jika tidak di-set
     required this.userID,
     required this.adminID,
-    required this.cardboardWeight,
+    this.cardboardWeight,
     required this.currentLocationLat,
     required this.currentLocationLong,
     required this.dateTime,
-    this.deliveryFee,
+    required this.deliveryFee,
     this.deliveryOption,
     required this.earnPoints,
-    required this.glassWeight,
+    this.glassWeight,
     required this.orderStatus,
     this.paymentType,
-    required this.plasticWeight,
-    required this.totalWeight,
+    this.plasticWeight,
+    this.totalWeight,
     required this.transactionType,
     this.dropID,
     this.name,
     this.address,
+    required this.totalWastePcs,
   });
 
-  factory TransactionModel.fromFirestore(Map<String, dynamic> data) {
+  // Menambahkan transactionId dari Firestore doc.id
+  factory TransactionModel.fromFirestore(
+      Map<String, dynamic> data, String id) {
     return TransactionModel(
+      transactionId: id, // Set transactionId dari doc.id
       userID: data['userID'] ?? '',
       adminID: data['adminID'] ?? '',
-      cardboardWeight: data['cardboardWeight'] ?? '',
+      cardboardWeight: data['cardboardWeight'],
       currentLocationLat: (data['currentLocationLat'] as num?)?.toDouble() ?? 0.0,
       currentLocationLong: (data['currentLocationLong'] as num?)?.toDouble() ?? 0.0,
       dateTime: (data['dateTime'] as Timestamp?)?.toDate() ?? DateTime.now(),
-      deliveryFee: data['deliveryFee'],
+      deliveryFee: data['deliveryFee'] ?? 0,
       deliveryOption: data['deliveryOption'],
       earnPoints: data['earnPoints'] ?? 0,
       glassWeight: data['glassWeight'] ?? 0,
-      orderStatus: data['orderStatus'],
+      orderStatus: data['orderStatus'] ?? '',
       paymentType: data['paymentType'],
       plasticWeight: data['plasticWeight'] ?? 0,
       totalWeight: data['totalWeight'] ?? 0,
       transactionType: data['transactionType'] ?? '',
       dropID: data['dropID'],
+      name: data['name'],
+      address: data['address'],
+      totalWastePcs: data['totalWastePcs'] ?? 0,
+    );
+  }
+
+  // Salinan model dengan properti yang diubah
+  TransactionModel copyWith({
+    String? transactionId,
+    String? userID,
+    String? adminID,
+    int? cardboardWeight,
+    double? currentLocationLat,
+    double? currentLocationLong,
+    DateTime? dateTime,
+    int? deliveryFee,
+    String? deliveryOption,
+    int? earnPoints,
+    int? glassWeight,
+    String? orderStatus,
+    String? paymentType,
+    int? plasticWeight,
+    int? totalWeight,
+    String? transactionType,
+    String? dropID,
+    String? name,
+    String? address,
+    int? totalWastePcs,
+  }) {
+    return TransactionModel(
+      transactionId: transactionId ?? this.transactionId,
+      userID: userID ?? this.userID,
+      adminID: adminID ?? this.adminID,
+      cardboardWeight: cardboardWeight ?? this.cardboardWeight,
+      currentLocationLat: currentLocationLat ?? this.currentLocationLat,
+      currentLocationLong: currentLocationLong ?? this.currentLocationLong,
+      dateTime: dateTime ?? this.dateTime,
+      deliveryFee: deliveryFee ?? this.deliveryFee,
+      deliveryOption: deliveryOption ?? this.deliveryOption,
+      earnPoints: earnPoints ?? this.earnPoints,
+      glassWeight: glassWeight ?? this.glassWeight,
+      orderStatus: orderStatus ?? this.orderStatus,
+      paymentType: paymentType ?? this.paymentType,
+      plasticWeight: plasticWeight ?? this.plasticWeight,
+      totalWeight: totalWeight ?? this.totalWeight,
+      transactionType: transactionType ?? this.transactionType,
+      dropID: dropID ?? this.dropID,
+      name: name ?? this.name,
+      address: address ?? this.address,
+      totalWastePcs: totalWastePcs ?? this.totalWastePcs,
     );
   }
 }

--- a/lib/features/send_empties/model/transaction_model.dart
+++ b/lib/features/send_empties/model/transaction_model.dart
@@ -3,38 +3,42 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class TransactionModel {
   final String userID;
   final String adminID;
-  final String cardboardWeight;
-  final double currenLocationLat;
-  final double currenLocationLong;
+  final int cardboardWeight;
+  final double currentLocationLat;
+  final double currentLocationLong;
   final DateTime dateTime;
-  final String deliveryFee;
-  final String deliveryOption;
+  final String? deliveryFee;
+  final String? deliveryOption;
   final int earnPoints;
   final int glassWeight;
   final String orderStatus;
-  final String paymentType;
+  final String? paymentType;
   final int plasticWeight;
   final int totalWeight;
   final String transactionType;
-  final String dropID;
+  final String? dropID;
+  final String? name;
+  final String? address;
 
   TransactionModel({
     required this.userID,
     required this.adminID,
     required this.cardboardWeight,
-    required this.currenLocationLat,
-    required this.currenLocationLong,
+    required this.currentLocationLat,
+    required this.currentLocationLong,
     required this.dateTime,
-    required this.deliveryFee,
-    required this.deliveryOption,
+    this.deliveryFee,
+    this.deliveryOption,
     required this.earnPoints,
     required this.glassWeight,
     required this.orderStatus,
-    required this.paymentType,
+    this.paymentType,
     required this.plasticWeight,
     required this.totalWeight,
     required this.transactionType,
-    required this.dropID,
+    this.dropID,
+    this.name,
+    this.address,
   });
 
   factory TransactionModel.fromFirestore(Map<String, dynamic> data) {
@@ -42,15 +46,15 @@ class TransactionModel {
       userID: data['userID'] ?? '',
       adminID: data['adminID'] ?? '',
       cardboardWeight: data['cardboardWeight'] ?? '',
-      currenLocationLat: (data['currenLocationLat'] as num?)?.toDouble() ?? 0.0,
-      currenLocationLong: (data['currenLocationLong'] as num?)?.toDouble() ?? 0.0,
+      currentLocationLat: (data['currentLocationLat'] as num?)?.toDouble() ?? 0.0,
+      currentLocationLong: (data['currentLocationLong'] as num?)?.toDouble() ?? 0.0,
       dateTime: (data['dateTime'] as Timestamp?)?.toDate() ?? DateTime.now(),
-      deliveryFee: data['deliveryFee'] ?? '',
-      deliveryOption: data['deliveryOption'] ?? '',
+      deliveryFee: data['deliveryFee'],
+      deliveryOption: data['deliveryOption'],
       earnPoints: data['earnPoints'] ?? 0,
       glassWeight: data['glassWeight'] ?? 0,
-      orderStatus: data['orderStatus'] ?? '',
-      paymentType: data['paymentType'] ?? '',
+      orderStatus: data['orderStatus'],
+      paymentType: data['paymentType'],
       plasticWeight: data['plasticWeight'] ?? 0,
       totalWeight: data['totalWeight'] ?? 0,
       transactionType: data['transactionType'] ?? '',

--- a/lib/features/send_empties/viewModel/user_form_view_model.dart
+++ b/lib/features/send_empties/viewModel/user_form_view_model.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:go_router/go_router.dart';
-import 'package:oktoast/oktoast.dart';
 import 'package:re_empties/cores/components/custom_toast_mixin.dart';
 import 'package:re_empties/cores/router/router_constant.dart';
 import 'package:re_empties/cores/template/notifer.dart';
@@ -220,8 +219,8 @@ class UserFormVM extends BaseNotifier with CustomToastMixin {
         'userID': currentUser?.uid ?? '',
         'adminID': adminID,
         'cardboardWeight': wasteQuantities['IwoJoghBYQQrmTRThjlk'],
-        'currenLocationLat': currentLat,
-        'currenLocationLong': currentLong,
+        'currentLocationLat': currentLat,
+        'currentLocationLong': currentLong,
         'dateTime': DateTime.now(),
         'deliveryFee': send ? 10000 : null,
         'deliveryOption': send ? selectedDeliveryTitle : null,

--- a/lib/features/send_empties/viewModel/user_form_view_model.dart
+++ b/lib/features/send_empties/viewModel/user_form_view_model.dart
@@ -213,24 +213,25 @@ class UserFormVM extends BaseNotifier with CustomToastMixin {
     send = isSend ?? false;
 
     if (validateForm()) {
-      final weight = wasteQuantities.values.fold(0, (sum, qty) => sum + qty);
-      final point = weight * 100;
+      final pcs = wasteQuantities.values.fold(0, (sum, qty) => sum + qty);
+      // final point = weight * 100;
       final transactionData = {
         'userID': currentUser?.uid ?? '',
         'adminID': adminID,
-        'cardboardWeight': wasteQuantities['IwoJoghBYQQrmTRThjlk'],
+        // 'cardboardWeight': wasteQuantities['IwoJoghBYQQrmTRThjlk'],
         'currentLocationLat': currentLat,
         'currentLocationLong': currentLong,
         'dateTime': DateTime.now(),
         'deliveryFee': send ? 10000 : null,
         'deliveryOption': send ? selectedDeliveryTitle : null,
-        'earnPoints': point,
-        'glassWeight': wasteQuantities['uuk14PI0XvaD5jZfouvy'],
-        'orderStatus': 'Done',
+        // 'earnPoints': point,
+        // 'glassWeight': wasteQuantities['uuk14PI0XvaD5jZfouvy'],
+        'orderStatus': send ? 'Order Received' : 'Delivery',
         'paymentType': selectedPaymentTitle,
-        'plasticWeight': wasteQuantities['JEO10T6Zlo3tmYcIYIMR'],
-        'totalWeight': weight,
+        // 'plasticWeight': wasteQuantities['JEO10T6Zlo3tmYcIYIMR'],
+        // 'totalWeight': weight,
         'transactionType': send ? 'Send' : 'Drop',
+        'totalWastePcs' : pcs,
       };
 
       await saveTransaction(adminID: adminID, transactionData: transactionData);

--- a/lib/features/send_empties/widget/custom_pinput.dart
+++ b/lib/features/send_empties/widget/custom_pinput.dart
@@ -111,7 +111,7 @@ class _CustomPinputState extends State<CustomPinput> {
             padding: EdgeInsets.only(top: 12.h),
             child: Text(
               errorText!,
-              style: textTheme.errorText.copyWith(color: colors.red1),
+              style: textTheme.errorText.copyWith(fontSize: 12.sp),
             ),
           ),
         ),


### PR DESCRIPTION
- fetch admin transaction data
- fix duplication global key (adjust navigation context)
- adjust sharedPreference for user and admin
- remove padding in article card
- move logout logic to profile from home
- filter for send/drop
- hide verified status of transaction
- adjust success page for admin
- added validation for dropID verification
- fetch admin data for profile
- added transaction card widget's ontap function
- adjust transaction and admin model
- loading logic adjusment

![Simulator Screenshot - iPhone 15 Pro - 2024-12-11 at 00 20 54](https://github.com/user-attachments/assets/2416c7d9-9820-4650-bfbe-7c80b0f8670e)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-11 at 00 21 00](https://github.com/user-attachments/assets/1d193a9d-6330-472e-9f0e-e30adf6df5f9)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-12 at 23 31 02](https://github.com/user-attachments/assets/bc206279-8e72-446c-985b-3c85bef9cb14)
![Simulator Screenshot - iPhone 15 Pro - 2024-12-12 at 23 31 37](https://github.com/user-attachments/assets/dc6ecfca-59ee-4413-acc8-507defb50244)
